### PR TITLE
Add postcss-cssnext instead of autoprefixer

### DIFF
--- a/felt.config.js
+++ b/felt.config.js
@@ -11,7 +11,7 @@ const
   commonjs = require('rollup-plugin-commonjs'),
   postcss = require('felt-postcss'),
   postcssImport = require('postcss-import'),
-  autoprefixer = require('autoprefixer')
+  cssnext = require('postcss-cssnext')
 
 module.exports = {
   // default handlers for each extension
@@ -27,7 +27,7 @@ module.exports = {
     '.css': postcss({
       plugins: [
         postcssImport(),
-        autoprefixer()
+        cssnext()
       ],
       options: {
         map: { inline: false }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "felt"
   ],
   "dependencies": {
-    "autoprefixer": "^6.3.5",
+    "postcss-cssnext": "^2.7.0",
     "felt-postcss": "^0.1.0",
     "felt-rollup": "^0.1.0",
     "postcss-import": "^8.0.2",


### PR DESCRIPTION
We can use only autoprefixer and postcss-import as PostCSS plugins by default.
So I put postcss-cssnext to enable using future CSS syntax.
